### PR TITLE
Add poolboy to list of applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Neo4jSips.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :httpoison, :poison, :con_cache],
+    [applications: [:logger, :httpoison, :poison, :con_cache, :poolboy],
      mod: {Neo4j.Sips, []}]
   end
 


### PR DESCRIPTION
Not totally sure about this change, but was having issues getting my project to run after building with exrm.

```
16:15:46.074 [info]  Application neo4j_sips exited: exited in: Neo4j.Sips.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) undefined function :poolboy.child_spec/3 (module :poolboy is not available)
            :poolboy.child_spec(:neo4j_sips_pool, [name: {:local, :neo4j_sips_pool}, worker_module: Neo4j.Sips.Connection, size: 5, max_overflow: 2], [url: "http://localhost:7474", pool_size: 5, max_overflow: 2, timeout: 60])
            (neo4j_sips) lib/neo4j_sips.ex:32: Neo4j.Sips.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4
{"Kernel pid terminated",application_controller,"{application_start_failure,neo4j_sips,{bad_return,{{'Elixir.Neo4j.Sips',start,[normal,[]]},{'EXIT',{undef,[{poolboy,child_spec,[neo4j_sips_pool,[{name,{local,neo4j_sips_pool}},{worker_module,'Elixir.Neo4j.Sips.Connection'},{size,5},{max_overflow,2}],[{url,<<\"http://localhost:7474\">>},{pool_size,5},{max_overflow,2},{timeout,60}]],[]},{'Elixir.Neo4j.Sips',start,2,[{file,\"lib/neo4j_sips.ex\"},{line,32}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,273}]}]}}}}}"}
```

Adding `:poolboy` to my project's applications list seemed to fix the issue, so moving that into neo4j sips would likely fix the issue as well. There's a little more discussion about a similar issue here: https://github.com/bitwalker/exrm/issues/284
