### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Neo4j.Sips
+Neo4j.Sips [![Deps Status](https://beta.hexfaktor.org/badge/all/github/florinpatrascu/neo4j_sips.svg)](https://beta.hexfaktor.org/github/florinpatrascu/neo4j_sips)
 ==========
 
 A simple Elixir wrapper around the [Neo4j](http://neo4j.com/developer/get-started/) graph database REST API.


### PR DESCRIPTION
Hi there,

I don't know if you are into badges, but I wanted to take a moment to pitch my latest project for the Elixir community:

  [![Deps Status](https://beta.hexfaktor.org/badge/all/github/florinpatrascu/neo4j_sips.svg)](https://beta.hexfaktor.org/github/florinpatrascu/neo4j_sips)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!
