### PR TITLE
Fix Access error bug

### DIFF
--- a/lib/neo4j_sips/query.ex
+++ b/lib/neo4j_sips/query.ex
@@ -34,7 +34,7 @@ defmodule Neo4j.Sips.Query do
   defp do_query!(result) do
     case result do
       {:ok, response} -> response
-      {:error, reason} ->  raise Neo4j.Sips.Error, code: reason["code"], message: reason["message"]
+      {:error, reason} ->  raise Neo4j.Sips.Error, code: reason.code, message: reason.message
     end
   end
 


### PR DESCRIPTION
Hi!

If there is an error with a parameterised query, then the following exception occurs:

```
** (exit) an exception was raised:
    ** (ArgumentError) the Access calls for keywords expect the key to be an atom, got: "code"
        (elixir) lib/access.ex:166: Access.fetch/2
        (elixir) lib/access.ex:179: Access.get/3
        (neo4j_sips) lib/neo4j_sips/query.ex:37: Neo4j.Sips.Query.do_query!/1
```

This PR fixes the Access errors by using dot notation to access the struct's members instead.
