### PR TITLE
The error path didn't work properly

### DIFF
--- a/lib/neo4j_sips/query.ex
+++ b/lib/neo4j_sips/query.ex
@@ -34,7 +34,7 @@ defmodule Neo4j.Sips.Query do
   defp do_query!(result) do
     case result do
       {:ok, response} -> response
-      {:error, reason} ->  raise Neo4j.Sips.Error, code: reason.code, message: reason.message
+      {:error, reason} ->  raise Neo4j.Sips.Error, code: hd(reason)["code"], message: hd(reason)["message"]
     end
   end
 


### PR DESCRIPTION
At least in my installation of neo4j 3.2.1, the "reason" was a list of length 1, with a map of keys of type string. I had to adjust this line.